### PR TITLE
Hide backticks in inline code

### DIFF
--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -165,6 +165,7 @@
   @apply prose-blockquote:rounded-lg prose-blockquote:border prose-blockquote:border-l-[10px] prose-blockquote:border-primary prose-blockquote:bg-theme-light prose-blockquote:px-8 prose-blockquote:py-10 prose-blockquote:font-secondary prose-blockquote:text-2xl prose-blockquote:not-italic prose-blockquote:text-dark prose-blockquote:dark:border-darkmode-primary prose-blockquote:dark:bg-darkmode-theme-light prose-blockquote:dark:text-darkmode-light;
   @apply prose-pre:rounded-lg prose-pre:bg-theme-light prose-pre:dark:bg-darkmode-theme-light;
   @apply prose-code:px-1 prose-code:text-primary prose-code:dark:text-darkmode-primary;
+  @apply prose-code:before:hidden prose-code:after:hidden;
   @apply prose-strong:text-dark prose-strong:dark:text-darkmode-text;
   @apply prose-a:text-text prose-a:underline hover:prose-a:text-primary prose-a:dark:text-darkmode-text hover:prose-a:dark:text-darkmode-primary;
   @apply prose-li:text-text prose-li:dark:text-darkmode-text;


### PR DESCRIPTION
By default, `inline code` looks like this on this project:
![before](https://github.com/user-attachments/assets/6374fa2f-b30c-4232-b5ac-cb501745fbfc)

The simple solution [was discussed here](https://github.com/tailwindlabs/tailwindcss-typography/issues/18), although the underlying issue is that Tailwind Typography is currently unable to distinguish between inline/block code and allow styling them separately ([see other PR](https://github.com/imochorg/astroplate/pull/2))

Now the code looks like this:
![Screenshot from 2024-08-24 10-25-31](https://github.com/user-attachments/assets/b2e324ff-b767-48b6-9153-a089efd2c00f)
